### PR TITLE
fix: use onLoad and properly pass in token to uploader options

### DIFF
--- a/examples/osmos-uploader-with-nextjs-and-typescript/.env
+++ b/examples/osmos-uploader-with-nextjs-and-typescript/.env
@@ -1,1 +1,1 @@
-UPLOADER_TOKEN="<add uploader token here>"
+NEXT_PUBLIC_UPLOADER_TOKEN=<add uploader token here>

--- a/examples/osmos-uploader-with-nextjs-and-typescript/src/app/page.tsx
+++ b/examples/osmos-uploader-with-nextjs-and-typescript/src/app/page.tsx
@@ -3,7 +3,7 @@ import Script from "next/script";
 import styles from "./page.module.css";
 
 export default function Home() {
-  const configureOptions = {
+  const configurationOptions = {
     schema: {
       fields: [
         {
@@ -13,12 +13,17 @@ export default function Home() {
         },
       ],
     },
+    token: process.env.NEXT_PUBLIC_UPLOADER_TOKEN,
   };
 
   return (
     <main className={styles.main}>
-      <Script src="https://cdn.osmos.io/button/embed/v1/OsmosButton.js"></Script>
-      <Script id="osmos-configure">{`Osmos.configure(${configureOptions});`}</Script>
+      <Script
+        src="https://cdn.osmos.io/button/embed/v1/OsmosButton.js"
+        onLoad={() => {
+          Osmos.configure(configurationOptions);
+        }}
+      ></Script>
       <button
         className="ftl-button"
         onClick={() =>

--- a/examples/osmos-uploader-with-nextjs-and-typescript/src/app/page.tsx
+++ b/examples/osmos-uploader-with-nextjs-and-typescript/src/app/page.tsx
@@ -28,7 +28,7 @@ export default function Home() {
         className="ftl-button"
         onClick={() =>
           // while the token is technically optional, the uploader will not work if it is not provided
-          window.Osmos.handleClick(process.env.NEXT_PUBLIC_UPLOADER_TOKEN)
+          window.Osmos.handleClick(configurationOptions.token)
         }
       >
         Upload Your Data


### PR DESCRIPTION
## Description

<!-- Describe your changes here -->
We had a customer point out some errors in the nextJS example
uses an onLoad function to prevent running the configuration option before the snippet has loaded
include the token in the configuration options
[ ] Descriptive folder name
[ ] No unnecessary files and code
[ ] README file
[ ] Added to top level README
